### PR TITLE
Add create folder functionality

### DIFF
--- a/client/src/components/FloatingButtons/FloatingButton.tsx
+++ b/client/src/components/FloatingButtons/FloatingButton.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from 'react';
 import { SvgNames, createSvg } from '../../shared/utils/svg-utils';
 import { styled, css } from 'styled-components';
 import { Keyframes } from 'styled-components/dist/types';
+import { Loader } from '../Loader';
 
 const Container = styled.div<{
 	$backgroundColor: string;
@@ -34,6 +35,7 @@ interface IProps {
 	icon: SvgNames;
 	animation?: Keyframes;
 	onClick?: () => void;
+	isLoading?: boolean;
 }
 
 const FloatingAddButton = ({
@@ -42,11 +44,16 @@ const FloatingAddButton = ({
 	onClick = undefined,
 	animation = undefined,
 	children,
+	isLoading = false,
 }: PropsWithChildren<IProps>): JSX.Element => {
 	return (
 		<Container $backgroundColor={color} $animation={animation} onClick={onClick}>
 			{children}
-			{createSvg(icon, 35, 'white')}
+			{isLoading ? (
+				<Loader size={20} backgroundColor='transparent' borderColor='white' />
+			) : (
+				createSvg(icon, 35, 'white')
+			)}
 		</Container>
 	);
 };

--- a/client/src/components/FloatingButtons/FloatingButtonsContainer.tsx
+++ b/client/src/components/FloatingButtons/FloatingButtonsContainer.tsx
@@ -9,7 +9,13 @@ import {
 	slideUp40pxAnimation,
 	slideUp70pxAnimation,
 } from './animation-keyframes';
-import { Nullable } from '../../shared/types/global.types';
+import { FileType, Nullable } from '../../shared/types/global.types';
+import { useAppDispatch } from '../../redux/store/store';
+import { openModal } from '../../redux/slices/modal/modalSlice';
+import { ModalKind } from '../../redux/slices/modal/types';
+import { useParams } from 'react-router-dom';
+import { createFolder } from '../../redux/async-actions/files.async.actions';
+import { getDriveTypeFromString } from '../../shared/utils/utils';
 
 const Container = styled.div`
 	position: absolute;
@@ -22,7 +28,10 @@ const FileOpenerInput = styled.input`
 `;
 
 export const FloatingButtonsContainer = (): JSX.Element => {
+	const dispatch = useAppDispatch();
+	const { folderId, email, drive: driveStr } = useParams();
 	const [menuOpen, setMenuOpen] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
 	const [plusButtonAnimation, setPlusButtonAnimation] = useState<Keyframes>();
 	const theme = useTheme();
 
@@ -40,6 +49,27 @@ export const FloatingButtonsContainer = (): JSX.Element => {
 	const uploadFile = (): void => {
 		//TODO: upload file here
 		console.log('upload file');
+	};
+
+	const onAddFolderClick = async () => {
+		const drive = getDriveTypeFromString(driveStr ?? '');
+		if (folderId && drive && email) {
+			try {
+				setIsLoading(true);
+				await dispatch(createFolder({ drive, email, parentFolderId: folderId }));
+				setIsLoading(false);
+			} catch {
+				setIsLoading(false);
+				//TODO: show toast
+			}
+		} else {
+			dispatch(
+				openModal({
+					kind: ModalKind.Upload,
+					state: { fileType: FileType.Folder },
+				})
+			);
+		}
 	};
 
 	return (
@@ -63,6 +93,8 @@ export const FloatingButtonsContainer = (): JSX.Element => {
 						icon={SvgNames.AddFolder}
 						color={theme?.colors.red ?? ''}
 						animation={slideUp40pxAnimation}
+						onClick={onAddFolderClick}
+						isLoading={isLoading}
 					/>
 				</>
 			)}

--- a/client/src/components/Loader.tsx
+++ b/client/src/components/Loader.tsx
@@ -18,12 +18,13 @@ const LoaderContainer = styled.div<LoaderContainerProps>`
 
 interface LoaderElementProps {
 	size: number;
+	$backgroundColor?: string;
+	$borderColor?: string;
 }
 const LoaderElement = styled.div<LoaderElementProps>`
-	border: 5px solid ${({ theme }) => theme.colors.border};
-	border-top: 5px solid ${({ theme }) => theme.colors.bluePrimary};
+	border: 5px solid ${({ theme, $backgroundColor }) => $backgroundColor ?? theme.colors.border};
+	border-top: 5px solid ${({ theme, $borderColor }) => $borderColor ?? theme.colors.bluePrimary};
 	border-radius: 50%;
-	margin-bottom: 10px;
 	animation: ${spinAnimation} 1s linear infinite;
 	${({ size }) => `height: ${size}px; width: ${size}px;`}
 `;
@@ -37,12 +38,23 @@ const LoadingText = styled.p`
 interface LoaderProps {
 	size: number;
 	showLoadingText?: boolean;
+	backgroundColor?: string;
+	borderColor?: string;
 }
 
-export const Loader = ({ showLoadingText = false, size }: LoaderProps): JSX.Element => {
+export const Loader = ({
+	size,
+	showLoadingText = false,
+	backgroundColor,
+	borderColor,
+}: LoaderProps): JSX.Element => {
 	return (
 		<LoaderContainer $showLoadingText={showLoadingText}>
-			<LoaderElement size={size} />
+			<LoaderElement
+				size={size}
+				$backgroundColor={backgroundColor}
+				$borderColor={borderColor}
+			/>
 			{showLoadingText && <LoadingText>Loading...</LoadingText>}
 		</LoaderContainer>
 	);

--- a/client/src/components/Modals/BaseModal.tsx
+++ b/client/src/components/Modals/BaseModal.tsx
@@ -62,13 +62,13 @@ const Footer = styled.div`
 	display: flex;
 	justify-content: space-between;
 	width: 90%;
-	border-top: 1px solid ${props => props.theme.colors.border};
 `;
 
 const ButtonsContainer = styled.div`
 	display: flex;
 	flex: 1;
 	justify-content: flex-end;
+	min-height: 30px;
 `;
 
 type ButtonProps = {

--- a/client/src/components/Modals/DeleteModal.tsx
+++ b/client/src/components/Modals/DeleteModal.tsx
@@ -71,30 +71,20 @@ export const DeleteModal = ({ state }: IProps): JSX.Element => {
 
 	const sendDeleteEntityRequest = async () => {
 		if (!entity) return;
-
-		if (isDriveEntity(entity)) {
-			const { email, type, id } = entity;
-			dispatch(deleteDrive({ email, type, id }));
-		} else if (isFileEntity(entity)) {
-			const { email, drive, id } = entity;
-			dispatch(deleteFile({ email, drive, id }));
+		try {
+			if (isDriveEntity(entity)) {
+				const { email, type, id } = entity;
+				await dispatch(deleteDrive({ email, type, id }));
+				dispatch(closeModals());
+			} else if (isFileEntity(entity)) {
+				const { email, drive, id } = entity;
+				await dispatch(deleteFile({ email, drive, id }));
+				dispatch(closeModals());
+			}
+		} catch {
+			//TODO: show toast
 		}
 	};
-
-	useEffect(() => {
-		const isDeleteDriveSuccessful = deleteDriveReq.done;
-		const isDeleteFileSuccessful = deleteFileReq.done;
-
-		if (isDeleteDriveSuccessful || isDeleteFileSuccessful) {
-			dispatch(closeModals());
-		}
-	}, [
-		deleteDriveReq.done,
-		deleteDriveReq.error,
-		deleteFileReq.done,
-		deleteFileReq.error,
-		dispatch,
-	]);
 
 	return (
 		<BaseModal

--- a/client/src/components/Modals/DeleteModal.tsx
+++ b/client/src/components/Modals/DeleteModal.tsx
@@ -7,7 +7,6 @@ import { DeleteModalState } from '../../redux/slices/modal/types';
 import { closeModals } from '../../redux/slices/modal/modalSlice';
 import { useAppDispatch, useAppSelector } from '../../redux/store/store';
 import { deleteDrive } from '../../redux/async-actions/drives.async.actions';
-import { useEffect } from 'react';
 import { deleteFile } from '../../redux/async-actions/files.async.actions';
 
 interface DeleteFileProps {
@@ -75,12 +74,11 @@ export const DeleteModal = ({ state }: IProps): JSX.Element => {
 			if (isDriveEntity(entity)) {
 				const { email, type, id } = entity;
 				await dispatch(deleteDrive({ email, type, id }));
-				dispatch(closeModals());
 			} else if (isFileEntity(entity)) {
 				const { email, drive, id } = entity;
 				await dispatch(deleteFile({ email, drive, id }));
-				dispatch(closeModals());
 			}
+			dispatch(closeModals());
 		} catch {
 			//TODO: show toast
 		}

--- a/client/src/components/Modals/RenameModal.tsx
+++ b/client/src/components/Modals/RenameModal.tsx
@@ -31,14 +31,13 @@ export const RenameModal = ({ state }: IProps): JSX.Element => {
 	const sendRenameFileRequest = async () => {
 		if (!entity) return;
 		const { drive, email, id } = entity;
-		dispatch(renameFile({ drive, email, id, newName: inputValue }));
-	};
-
-	useEffect(() => {
-		if (renameFileReq.done) {
+		try {
+			await dispatch(renameFile({ drive, email, id, newName: inputValue }));
 			dispatch(closeModals());
+		} catch {
+			//TODO: show toast
 		}
-	}, [dispatch, renameFileReq.done]);
+	};
 
 	return (
 		<BaseModal

--- a/client/src/hooks/useFetchFolderContents.ts
+++ b/client/src/hooks/useFetchFolderContents.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { getRootFiles, getFolderDriveFiles } from '../redux/async-actions/files.async.actions';
 import { useAppDispatch } from '../redux/store/store';
 import { DriveType, Nullable } from '../shared/types/global.types';
+import { getDriveTypeFromString } from '../shared/utils/utils';
 
 export const useFetchFolderContents = () => {
 	const dispatch = useAppDispatch();
@@ -22,18 +23,4 @@ export const useFetchFolderContents = () => {
 			dispatch(getRootFiles());
 		}
 	}, [dispatch, pathParams]);
-};
-
-// Helpers
-const getDriveTypeFromString = (driveTypeAsString: string): Nullable<DriveType> => {
-	switch (driveTypeAsString) {
-		case DriveType.Dropbox:
-			return DriveType.Dropbox;
-		case DriveType.GoogleDrive:
-			return DriveType.GoogleDrive;
-		case DriveType.OneDrive:
-			return DriveType.OneDrive;
-		default:
-			return null;
-	}
 };

--- a/client/src/redux/async-actions/files.async.actions.ts
+++ b/client/src/redux/async-actions/files.async.actions.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { DriveType } from '../../shared/types/global.types';
+import { DriveType, FileType } from '../../shared/types/global.types';
 import FilesService from '../../services/drives/files/drives.files.service';
 
 export const getRootFiles = createAsyncThunk('files/getRootFiles', async () => {
@@ -49,5 +49,14 @@ export const unshareFile = createAsyncThunk(
 	async ({ drive, email, id }: UnshareFileParams) => {
 		await FilesService.unshareDriveFile(drive, email, id);
 		return id;
+	}
+);
+
+type CreateFolderParams = { drive: DriveType; email: string; parentFolderId?: string };
+export const createFolder = createAsyncThunk(
+	'files/createFolder',
+	async ({ drive, email, parentFolderId }: CreateFolderParams) => {
+		const folder = await FilesService.createFile(drive, email, FileType.Folder, parentFolderId);
+		return folder;
 	}
 );

--- a/client/src/redux/slices/files/filesSlice.ts
+++ b/client/src/redux/slices/files/filesSlice.ts
@@ -13,6 +13,7 @@ import {
 	renameFile,
 	shareFile,
 	unshareFile,
+	createFolder,
 } from '../../async-actions/files.async.actions';
 import { logoutUser } from '../../async-actions/user.async.actions';
 import { deleteDrive, getChanges } from '../../async-actions/drives.async.actions';
@@ -27,6 +28,7 @@ const initialState: FilesState = {
 		renameFile: requestInitialState,
 		shareFile: requestInitialState,
 		unshareFile: requestInitialState,
+		createFolder: requestInitialState,
 	},
 };
 
@@ -79,6 +81,7 @@ const filesSlice = createSlice({
 			.addCase(renameFile.pending, state => {
 				state.requests.renameFile = requestPendingState;
 			})
+			//TODO: utilize immer instead of temp shit
 			.addCase(renameFile.fulfilled, (state, { payload }) => {
 				const { name, id } = payload;
 				const fileForUpdateIndex = state.files.findIndex(file => file.id === id);
@@ -113,6 +116,7 @@ const filesSlice = createSlice({
 			.addCase(unshareFile.pending, state => {
 				state.requests.unshareFile = requestPendingState;
 			})
+			//TODO: utilize immer instead of temp shit
 			.addCase(unshareFile.fulfilled, (state, { payload: id }) => {
 				const fileForUpdateIndex = state.files.findIndex(file => file.id === id);
 				const tempFiles = [...state.files];
@@ -124,9 +128,23 @@ const filesSlice = createSlice({
 				state.requests.unshareFile = requestErrorState;
 			});
 
+		// createFolder
+		builder
+			.addCase(createFolder.pending, state => {
+				state.requests.createFolder = requestPendingState;
+			})
+			//TODO: utilize immer instead of temp shit
+			.addCase(createFolder.fulfilled, (state, { payload: folder }) => {
+				state.files.unshift(folder);
+				state.requests.createFolder = requestSuccessState;
+			})
+			.addCase(createFolder.rejected, state => {
+				state.requests.createFolder = requestErrorState;
+			});
+
 		// deleteDrive
 		builder.addCase(deleteDrive.fulfilled, (state, { payload }) => {
-			const { type, email } = payload;
+			const { type, email } = payload; //TODO: Fix issue
 			state.files = state.files.filter(file => file.email !== email && file.drive !== type);
 		});
 

--- a/client/src/redux/slices/files/types.ts
+++ b/client/src/redux/slices/files/types.ts
@@ -10,5 +10,6 @@ export interface FilesState {
 		renameFile: RequestState;
 		shareFile: RequestState;
 		unshareFile: RequestState;
+		createFolder: RequestState;
 	};
 }

--- a/client/src/redux/slices/modal/types.ts
+++ b/client/src/redux/slices/modal/types.ts
@@ -1,5 +1,5 @@
-import { FileEntity, Nullable } from '../../../shared/types/global.types';
-import { Entity, FileType, MultiMediaType } from '../../../shared/types/types';
+import { FileEntity, FileType, Nullable } from '../../../shared/types/global.types';
+import { Entity, MultiMediaType } from '../../../shared/types/types';
 
 export type DeleteModalState = {
 	entity: Nullable<Entity>;

--- a/client/src/services/drives/files/drives.files.service.ts
+++ b/client/src/services/drives/files/drives.files.service.ts
@@ -5,28 +5,38 @@ import {
 	PatchFileRequestBody,
 	PatchFileResponse,
 	Nullable,
+	CreateFileRequestBody,
+	FileType,
 } from '../../../shared/types/global.types';
 import RequestService from '../../request.service';
 
 export class FilesService {
-	async getRootFiles(): Promise<FileEntity[]> {
+	public async getRootFiles(): Promise<FileEntity[]> {
 		const { data: fileEntities } = await RequestService.get<FileEntity[]>('/drives/files');
 		return fileEntities;
 	}
 
-	async getFolderFiles(drive: DriveType, email: string, id: string): Promise<FileEntity[]> {
+	public async getFolderFiles(
+		drive: DriveType,
+		email: string,
+		id: string
+	): Promise<FileEntity[]> {
 		const { data: fileEntities } = await RequestService.get<FileEntity[]>(
 			`drives/${drive}/${email}/files/${id}`
 		);
 		return fileEntities;
 	}
 
-	async deleteDriveFile(drive: DriveType, driveEmail: string, fileId: string): Promise<boolean> {
+	public async deleteDriveFile(
+		drive: DriveType,
+		driveEmail: string,
+		fileId: string
+	): Promise<boolean> {
 		const res = await RequestService.delete(`drives/${drive}/${driveEmail}/files/${fileId}`);
 		return res.status === Status.OK;
 	}
 
-	async renameDriveFile(
+	public async renameDriveFile(
 		drive: DriveType,
 		driveEmail: string,
 		fileId: string,
@@ -40,7 +50,7 @@ export class FilesService {
 		return renameData && renameData.success ? renameData.name : '';
 	}
 
-	async shareDriveFile(
+	public async shareDriveFile(
 		drive: DriveType,
 		driveEmail: string,
 		fileId: string
@@ -54,13 +64,34 @@ export class FilesService {
 		return shareData && shareData.success ? shareData.sharedLink : null;
 	}
 
-	async unshareDriveFile(drive: DriveType, driveEmail: string, fileId: string): Promise<boolean> {
-		const res = await RequestService.patch<PatchFileRequestBody, PatchFileResponse>(
+	public async unshareDriveFile(
+		drive: DriveType,
+		driveEmail: string,
+		fileId: string
+	): Promise<boolean> {
+		const { data } = await RequestService.patch<PatchFileRequestBody, PatchFileResponse>(
 			`drives/${drive}/${driveEmail}/files/${fileId}`,
 			{ share: false }
 		);
-		const unshareData = res.data.operation.unshare;
+		const unshareData = data.operation.unshare;
 		return unshareData && unshareData.success ? true : false;
+	}
+
+	public async createFile(
+		drive: DriveType,
+		driveEmail: string,
+		type: FileType,
+		parentFolderId?: string
+	) {
+		const res = await RequestService.post<CreateFileRequestBody, FileEntity>(
+			`drives/${drive}/${driveEmail}/files`,
+			{
+				type,
+				parentFolderId,
+			}
+		);
+
+		return res.data;
 	}
 }
 

--- a/client/src/shared/types/global.types.ts
+++ b/client/src/shared/types/global.types.ts
@@ -51,6 +51,11 @@ export interface PatchFileResponse {
 	};
 }
 
+export interface CreateFileRequestBody {
+	type: FileType;
+	parentFolderId?: string;
+}
+
 export enum Status {
 	OK = 200,
 	BAD_REQUEST = 400,

--- a/client/src/shared/utils/utils.ts
+++ b/client/src/shared/utils/utils.ts
@@ -32,3 +32,16 @@ export const formatBytes = (bytes: number, decimals = 2) => {
 
 	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 };
+
+export const getDriveTypeFromString = (driveType: string): Nullable<DriveType> => {
+	switch (driveType) {
+		case DriveType.Dropbox:
+			return DriveType.Dropbox;
+		case DriveType.GoogleDrive:
+			return DriveType.GoogleDrive;
+		case DriveType.OneDrive:
+			return DriveType.OneDrive;
+		default:
+			return null;
+	}
+};

--- a/server/src/api/v1/drives/files/drives.files.controllers.ts
+++ b/server/src/api/v1/drives/files/drives.files.controllers.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { AuthLocals } from '../../../../types/types';
 import FilesService from './drives.files.service';
 import {
+	CreateFileRequestBody,
 	DriveType,
 	FileEntity,
 	PatchFileRequestBody,
@@ -10,7 +11,10 @@ import {
 } from '../../../../types/global.types';
 
 class FilesController {
-	async getRootFiles(req: Request, res: Response<FileEntity[], AuthLocals>): Promise<void> {
+	public async getRootFiles(
+		_req: Request,
+		res: Response<FileEntity[], AuthLocals>
+	): Promise<void> {
 		const { email } = res.locals;
 		const files = await FilesService.getRootFiles(email);
 
@@ -21,7 +25,7 @@ class FilesController {
 		}
 	}
 
-	async getFolderFiles(
+	public async getFolderFiles(
 		req: Request<{ drive: DriveType; email: string; folderId: string }>,
 		res: Response<FileEntity[], AuthLocals>
 	): Promise<void> {
@@ -36,7 +40,7 @@ class FilesController {
 		}
 	}
 
-	async deleteFile(
+	public async deleteFile(
 		req: Request<{ drive: DriveType; email: string; fileId: string }>,
 		res: Response<void, AuthLocals>
 	): Promise<void> {
@@ -48,7 +52,7 @@ class FilesController {
 		res.status(statusId).send();
 	}
 
-	async editFile(
+	public async editFile(
 		req: Request<
 			{ drive: DriveType; email: string; fileId: string },
 			void,
@@ -109,6 +113,29 @@ class FilesController {
 
 		if (renameSuccess || shareSuccess || unshareSuccess) {
 			res.status(Status.OK).send(responseBody);
+		} else {
+			res.status(Status.INTERNAL_SERVER_ERROR).send();
+		}
+	}
+
+	public async createFile(
+		req: Request<{ drive: DriveType; email: string }, void, CreateFileRequestBody>,
+		res: Response<FileEntity, AuthLocals>
+	): Promise<void> {
+		const { email: userEmail } = res.locals;
+		const { drive, email: driveEmail } = req.params;
+		const { type, parentFolderId } = req.body;
+
+		const file = await FilesService.createFile(
+			drive,
+			userEmail,
+			driveEmail,
+			type,
+			parentFolderId
+		);
+
+		if (file) {
+			res.status(Status.OK).send(file);
 		} else {
 			res.status(Status.INTERNAL_SERVER_ERROR).send();
 		}

--- a/server/src/api/v1/drives/files/drives.files.routes.ts
+++ b/server/src/api/v1/drives/files/drives.files.routes.ts
@@ -5,6 +5,7 @@ import FilesController from './drives.files.controllers';
 const router: Router = express.Router();
 router.get('/files', authorize, FilesController.getRootFiles);
 router.get('/:drive/:email/files/:folderId', authorize, FilesController.getFolderFiles);
+router.post('/:drive/:email/files', authorize, FilesController.createFile);
 router.delete('/:drive/:email/files/:fileId', authorize, FilesController.deleteFile);
 router.patch('/:drive/:email/files/:fileId', authorize, FilesController.editFile);
 

--- a/server/src/api/v1/drives/files/drives.files.service.ts
+++ b/server/src/api/v1/drives/files/drives.files.service.ts
@@ -1,5 +1,5 @@
 import DatabaseService from '../../../../services/database/mongodb.service';
-import { DriveType, FileEntity, Nullable } from '../../../../types/global.types';
+import { DriveType, FileEntity, FileType, Nullable } from '../../../../types/global.types';
 import { getDriveContextAndToken } from '../drives.helpers';
 
 export class FilesService {
@@ -26,11 +26,13 @@ export class FilesService {
 						fileEntities.push(list);
 					}
 				});
+
 				return fileEntities.flat() ?? null;
 			} catch {
 				return null;
 			}
 		}
+
 		return null;
 	}
 
@@ -45,6 +47,7 @@ export class FilesService {
 			driveEmail,
 			drive
 		);
+
 		if (encryptedTokenStr) {
 			const ctxAndToken = getDriveContextAndToken(drive, encryptedTokenStr);
 			if (ctxAndToken) {
@@ -52,6 +55,7 @@ export class FilesService {
 				return ctx.getDriveFiles(token, folderId);
 			}
 		}
+
 		return null;
 	}
 
@@ -66,6 +70,7 @@ export class FilesService {
 			driveEmail,
 			drive
 		);
+
 		if (encryptedTokenStr) {
 			const ctxAndToken = getDriveContextAndToken(drive, encryptedTokenStr);
 			if (ctxAndToken) {
@@ -73,6 +78,7 @@ export class FilesService {
 				return ctx.deleteFile(token, fileId);
 			}
 		}
+
 		return false;
 	}
 
@@ -88,6 +94,7 @@ export class FilesService {
 			driveEmail,
 			drive
 		);
+
 		if (encryptedTokenStr) {
 			const ctxAndToken = getDriveContextAndToken(drive, encryptedTokenStr);
 			if (ctxAndToken) {
@@ -95,6 +102,7 @@ export class FilesService {
 				return ctx.renameFile(token, fileId, name);
 			}
 		}
+
 		return false;
 	}
 
@@ -109,6 +117,7 @@ export class FilesService {
 			driveEmail,
 			drive
 		);
+
 		if (encryptedTokenStr) {
 			const ctxAndToken = getDriveContextAndToken(drive, encryptedTokenStr);
 			if (ctxAndToken) {
@@ -116,6 +125,7 @@ export class FilesService {
 				return ctx.shareFile(token, fileId);
 			}
 		}
+
 		return null;
 	}
 
@@ -130,6 +140,7 @@ export class FilesService {
 			driveEmail,
 			drive
 		);
+
 		if (encryptedTokenStr) {
 			const ctxAndToken = getDriveContextAndToken(drive, encryptedTokenStr);
 			if (ctxAndToken) {
@@ -137,7 +148,32 @@ export class FilesService {
 				return ctx.unshareFile(token, fileId);
 			}
 		}
+
 		return false;
+	}
+
+	async createFile(
+		drive: DriveType,
+		userEmail: string,
+		driveEmail: string,
+		fileType: FileType,
+		parentFolderId?: string
+	): Promise<Nullable<FileEntity>> {
+		const encryptedTokenStr = await DatabaseService.getEncryptedTokenAsString(
+			userEmail,
+			driveEmail,
+			drive
+		);
+
+		if (encryptedTokenStr) {
+			const ctxAndToken = getDriveContextAndToken(drive, encryptedTokenStr);
+			if (ctxAndToken) {
+				const { ctx, token } = ctxAndToken;
+				return ctx.createFile(token, fileType, parentFolderId);
+			}
+		}
+
+		return null;
 	}
 }
 

--- a/server/src/middleware/authorize.ts
+++ b/server/src/middleware/authorize.ts
@@ -3,14 +3,15 @@ import { Request, Response } from 'express';
 import { AuthLocals } from '../types/types';
 import { Status } from '../types/global.types';
 
-export default function (req: Request, res: Response, next: () => any) {
+export default function (req: Request, res: Response<{}, AuthLocals>, next: () => any) {
 	const secret = process.env.JWT_SECRET!;
 	const token = req.cookies.token;
 
 	try {
 		//TODO: check if its enough. what happens if you send your own cookie ?
+		//TODO FIX ALL, User deleted
 		const decoded = jwt.verify(token, secret) as jwt.JwtPayload;
-		(res.locals as AuthLocals).email = decoded.email;
+		res.locals.email = decoded.email;
 		next();
 	} catch (err) {
 		res.status(Status.UNAUTHORIZED).send();

--- a/server/src/services/drive/DriveContext.ts
+++ b/server/src/services/drive/DriveContext.ts
@@ -2,6 +2,7 @@ import {
 	DriveChanges,
 	DriveQuota,
 	FileEntity,
+	FileType,
 	Nullable,
 	WatchChangesChannel,
 } from '../../types/global.types';
@@ -52,6 +53,14 @@ export default class DriveContext {
 
 	public async unshareFile(token: string, fileId: string): Promise<boolean> {
 		return this.strategy.unshareFile(token, fileId);
+	}
+
+	public async createFile(
+		token: string,
+		fileType: FileType,
+		parentFolderId?: string
+	): Promise<Nullable<FileEntity>> {
+		return this.strategy.createFile(token, fileType, parentFolderId);
 	}
 
 	public async subscribeForChanges(

--- a/server/src/services/drive/GoogleDriveStrategy.ts
+++ b/server/src/services/drive/GoogleDriveStrategy.ts
@@ -350,6 +350,7 @@ export default class GoogleDriveStrategy implements IDriveStrategy {
 		return folderId ? folderFilesQuery : rootFilesQuery;
 	}
 
+	//TODO: make it better check samo comment
 	private mapToUniversalFileEntityFormat(
 		files: GoogleDriveFile[],
 		driveEmail: string

--- a/server/src/services/drive/GoogleDriveStrategy.ts
+++ b/server/src/services/drive/GoogleDriveStrategy.ts
@@ -105,6 +105,7 @@ export default class GoogleDriveStrategy implements IDriveStrategy {
 			});
 			const files = res.data.files;
 			const driveEmail = await this.getUserDriveEmail(token);
+
 			return files ? this.mapToUniversalFileEntityFormat(files, driveEmail) : null;
 		} catch {
 			return null;
@@ -135,6 +136,34 @@ export default class GoogleDriveStrategy implements IDriveStrategy {
 			return true;
 		} catch {
 			return false;
+		}
+	}
+
+	public async createFile(
+		token: string,
+		fileType: FileType,
+		parentFolderId?: string
+	): Promise<Nullable<FileEntity>> {
+		try {
+			this.setToken(token);
+			const mimeType =
+				fileType === FileType.Folder
+					? 'application/vnd.google-apps.folder'
+					: 'application/octet-stream';
+
+			const res = await this.drive.files.create({
+				requestBody: {
+					name: 'New Folder',
+					mimeType,
+					parents: parentFolderId ? [parentFolderId] : [],
+				},
+				fields: 'id, name, mimeType, createdTime',
+			});
+			const driveEmail = await this.getUserDriveEmail(token);
+
+			return this.mapToUniversalFileEntityFormat(res.data, driveEmail);
+		} catch {
+			return null;
 		}
 	}
 
@@ -324,7 +353,14 @@ export default class GoogleDriveStrategy implements IDriveStrategy {
 	private mapToUniversalFileEntityFormat(
 		files: GoogleDriveFile[],
 		driveEmail: string
-	): FileEntity[] {
+	): FileEntity[];
+	private mapToUniversalFileEntityFormat(file: GoogleDriveFile, driveEmail: string): FileEntity;
+	private mapToUniversalFileEntityFormat(
+		fileOrFiles: GoogleDriveFile[] | GoogleDriveFile,
+		driveEmail: string
+	): FileEntity[] | FileEntity {
+		const isArrayOfFiles = Array.isArray(fileOrFiles);
+		const files = isArrayOfFiles ? fileOrFiles : [fileOrFiles];
 		const driveEntities: FileEntity[] = files.map(file => {
 			const fileType = this.determineEntityType(file.mimeType ?? '');
 			const size = fileType === FileType.File ? normalizeBytes(file.size ?? '') : '';
@@ -345,7 +381,7 @@ export default class GoogleDriveStrategy implements IDriveStrategy {
 			};
 		});
 
-		return driveEntities;
+		return isArrayOfFiles ? driveEntities : driveEntities[0];
 	}
 
 	private determineEntityType(mimeType?: string): FileType {

--- a/server/src/services/drive/IDriveStrategy.ts
+++ b/server/src/services/drive/IDriveStrategy.ts
@@ -4,6 +4,7 @@ import {
 	Nullable,
 	WatchChangesChannel,
 	DriveChanges,
+	FileType,
 } from '../../types/global.types';
 
 export interface IDriveStrategy {
@@ -16,6 +17,11 @@ export interface IDriveStrategy {
 	renameFile(token: string, fileId: string, name: string): Promise<boolean>;
 	shareFile(token: string, fileId: string): Promise<Nullable<string>>;
 	unshareFile(token: string, fileId: string): Promise<boolean>;
+	createFile(
+		token: string,
+		fileType: FileType,
+		parentFolderId?: string
+	): Promise<Nullable<FileEntity>>;
 	subscribeForChanges(
 		token: string,
 		driveEmail: string

--- a/server/src/types/global.types.ts
+++ b/server/src/types/global.types.ts
@@ -49,6 +49,11 @@ export interface PatchFileResponse {
 	};
 }
 
+export interface CreateFileRequestBody {
+	type: FileType;
+	parentFolderId?: string;
+}
+
 export enum Status {
 	OK = 200,
 	BAD_REQUEST = 400,


### PR DESCRIPTION
When on root page, if add folder floating button is clicked it will open the Upload modal with a list of the currently connected drives. If you select a drive from the list the folder will be created to that drive

When inside a folder, it will automatically create the folder inside that folder

I also added a loader on the floating button when the create folder request is sent

Also fixed issues on rename, delete