### PR TITLE
Hide sidepanel inside folder

### DIFF
--- a/client/src/components/FloatingButtons/FloatingButtonsContainer.tsx
+++ b/client/src/components/FloatingButtons/FloatingButtonsContainer.tsx
@@ -15,7 +15,6 @@ import { openModal } from '../../redux/slices/modal/modalSlice';
 import { ModalKind } from '../../redux/slices/modal/types';
 import { useParams } from 'react-router-dom';
 import { createFolder } from '../../redux/async-actions/files.async.actions';
-import { getDriveTypeFromString } from '../../shared/utils/utils';
 
 const Container = styled.div`
 	position: absolute;

--- a/client/src/components/TitleBanner.tsx
+++ b/client/src/components/TitleBanner.tsx
@@ -7,6 +7,7 @@ import { Nullable } from '../shared/types/global.types';
 import { useAppSelector } from '../redux/store/store';
 import { useNavigate } from 'react-router-dom';
 import { routes } from '../shared/constants/routes';
+import { useIsInsideFolder } from '../hooks/useIsInsideFolder';
 
 const BannerContainer = styled.div`
 	display: flex;
@@ -98,6 +99,8 @@ interface TitleBannerProps {
 export const TitleBanner = (props: TitleBannerProps): JSX.Element => {
 	const navigate = useNavigate();
 	const isAuthenticated = useAppSelector(state => state.user.isAuthenticated);
+	const isInsideFolder = useIsInsideFolder();
+
 	const virtualQuotaLoading = false;
 	const virtualQuotaStr = '5 / 5 GB';
 	const virtualDriveEnabled = false;
@@ -109,9 +112,11 @@ export const TitleBanner = (props: TitleBannerProps): JSX.Element => {
 	return (
 		<BannerContainer>
 			<LogoMenuContainer>
-				<BurgerMenuButton onClick={props.onBurgerMenuClick}>
-					{createSvg(SvgNames.Burger, 30, 'white')}
-				</BurgerMenuButton>
+				{!isInsideFolder && (
+					<BurgerMenuButton onClick={props.onBurgerMenuClick}>
+						{createSvg(SvgNames.Burger, 30, 'white')}
+					</BurgerMenuButton>
+				)}
 				<LogoTitle onClick={navigateToDrivePath}>aio drive</LogoTitle>
 			</LogoMenuContainer>
 			{virtualDriveEnabled && (

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -4,3 +4,5 @@ export * from './useHandleAuthCodeFromUrl';
 export * from './useOutsideClicker';
 export * from './useServerSideEvents';
 export * from './useSubscribeForDriveChanges';
+
+//TODO: add the rest aswell

--- a/client/src/hooks/useActiveDriveFiles.ts
+++ b/client/src/hooks/useActiveDriveFiles.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useAppSelector } from '../redux/store/store';
 import { FileEntity } from '../shared/types/global.types';
+import { useIsInsideFolder } from './useIsInsideFolder';
 
 export const useActiveDriveFiles = () => {
 	const drives = useAppSelector(state => state.drives.drives);
 	const files = useAppSelector(state => state.files.files);
 	const [filteredFiles, setFilteredFiles] = useState<FileEntity[]>([]);
+	const isInsideFolder = useIsInsideFolder();
 
 	useEffect(() => {
 		const nextFilteredFiles = files.filter(file =>
@@ -17,5 +19,5 @@ export const useActiveDriveFiles = () => {
 		setFilteredFiles(nextFilteredFiles);
 	}, [drives, files]);
 
-	return filteredFiles;
+	return isInsideFolder ? files : filteredFiles;
 };

--- a/client/src/hooks/useIsInsideFolder.ts
+++ b/client/src/hooks/useIsInsideFolder.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const useIsInsideFolder = () => {
+	const pathParams = useParams();
+	const [isInsideFolder, setIsInsideFolder] = useState<boolean>(false);
+
+	useEffect(() => {
+		const { driveId, folderId } = pathParams;
+		setIsInsideFolder(!!driveId && !!folderId);
+	}, [pathParams]);
+
+	return isInsideFolder;
+};

--- a/client/src/pages/DrivePage.tsx
+++ b/client/src/pages/DrivePage.tsx
@@ -20,6 +20,7 @@ import { routes } from '../shared/constants/routes';
 import { useAppSelector } from '../redux/store/store';
 import { FilesList } from '../components/FilesList';
 import { useFetchFolderContents } from '../hooks/useFetchFolderContents';
+import { useIsInsideFolder } from '../hooks/useIsInsideFolder';
 
 const OuterContainer = styled.div`
 	display: flex;
@@ -42,6 +43,7 @@ const RowsScrollview = styled.div`
 export const DrivePage = (): JSX.Element => {
 	const [sideMenuVisible, setSideMenuVisible] = useState(true);
 	const isUserAuthenticated = useAppSelector(state => state.user.isAuthenticated);
+	const isInsideFolder = useIsInsideFolder();
 
 	useCheckAuth();
 	useHandleAuthCodeFromUrl();
@@ -54,7 +56,7 @@ export const DrivePage = (): JSX.Element => {
 	return isUserAuthenticated ? (
 		<OuterContainer>
 			<InnerContainer>
-				{sideMenuVisible && <SideMenu />}
+				{sideMenuVisible && !isInsideFolder && <SideMenu />}
 				<RowsScrollview>
 					<TitleBanner
 						onBurgerMenuClick={() => {


### PR DESCRIPTION
We hide the panel inside a folder since the files there belong only to a single drive. No reason to have the active/inactive drive file filtering there